### PR TITLE
feat: edit team & explore tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-tooltip": "^1.0.6",
     "@t3-oss/env-nextjs": "^0.3.1",
     "@tanstack/react-query": "^4.29.7",
+    "@tanstack/react-query-devtools": "4",
     "@trpc/client": "^10.26.0",
     "@trpc/next": "^10.26.0",
     "@trpc/react-query": "^10.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ dependencies:
   '@tanstack/react-query':
     specifier: ^4.29.7
     version: 4.32.6(react-dom@18.2.0)(react@18.2.0)
+  '@tanstack/react-query-devtools':
+    specifier: '4'
+    version: 4.36.1(@tanstack/react-query@4.32.6)(react-dom@18.2.0)(react@18.2.0)
   '@trpc/client':
     specifier: ^10.26.0
     version: 10.37.1(@trpc/server@10.37.1)
@@ -2311,8 +2314,30 @@ packages:
       zod: 3.21.4
     dev: false
 
+  /@tanstack/match-sorter-utils@8.15.1:
+    resolution: {integrity: sha512-PnVV3d2poenUM31ZbZi/yXkBu3J7kd5k2u51CGwwNojag451AjTH9N6n41yjXz2fpLeewleyLBmNS6+HcGDlXw==}
+    engines: {node: '>=12'}
+    dependencies:
+      remove-accents: 0.5.0
+    dev: false
+
   /@tanstack/query-core@4.32.6:
     resolution: {integrity: sha512-YVB+mVWENQwPyv+40qO7flMgKZ0uI41Ph7qXC2Zf1ft5AIGfnXnMZyifB2ghhZ27u+5wm5mlzO4Y6lwwadzxCA==}
+    dev: false
+
+  /@tanstack/react-query-devtools@4.36.1(@tanstack/react-query@4.32.6)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-WYku83CKP3OevnYSG8Y/QO9g0rT75v1om5IvcWUwiUZJ4LanYGLVCZ8TdFG5jfsq4Ej/lu2wwDAULEUnRIMBSw==}
+    peerDependencies:
+      '@tanstack/react-query': ^4.36.1
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@tanstack/match-sorter-utils': 8.15.1
+      '@tanstack/react-query': 4.32.6(react-dom@18.2.0)(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      superjson: 1.12.2
+      use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
   /@tanstack/react-query@4.32.6(react-dom@18.2.0)(react@18.2.0):
@@ -5252,6 +5277,10 @@ packages:
       define-properties: 1.2.0
       functions-have-names: 1.2.3
     dev: true
+
+  /remove-accents@0.5.0:
+    resolution: {integrity: sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==}
+    dev: false
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}

--- a/src/core/dashboard/teams/Explore.tsx
+++ b/src/core/dashboard/teams/Explore.tsx
@@ -1,8 +1,7 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useDebounce } from '~/hooks/useDebounce';
-import { FilterIcon, SearchIcon } from 'lucide-react';
-import { Button } from '~/components/ui/Button';
+import { SearchIcon } from 'lucide-react';
 import { Input } from '~/components/ui/Input';
 import TeamList from './TeamList';
 import { api } from '~/utils/api';
@@ -123,9 +122,6 @@ export default function Explore() {
           />
           <SearchIcon className='absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400' />
         </div>
-        <Button variant='ghost' className='h-9 w-9 px-0'>
-          <FilterIcon className='h-[18px] w-[18px] text-slate-50' />
-        </Button>
       </div>
       <TeamList data={data} error={error} status={status} />
     </>

--- a/src/core/dashboard/teams/Explore.tsx
+++ b/src/core/dashboard/teams/Explore.tsx
@@ -38,7 +38,7 @@ function useSearchQuery() {
     if (router.query.q !== searchQuery) {
       setSearchQuery((router.query.q as string | undefined) ?? '');
     }
-    // Disabled due to causing of infinite loop
+    // disabled due to infinite loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.query.q]);
 

--- a/src/core/dashboard/teams/Explore.tsx
+++ b/src/core/dashboard/teams/Explore.tsx
@@ -1,9 +1,49 @@
-import { FilterIcon, SearchIcon } from 'lucide-react';
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import { useDebounce } from '~/hooks/useDebounce';
+import { FilterIcon, SearchIcon } from 'lucide-react';
 import { Button } from '~/components/ui/Button';
 import { Input } from '~/components/ui/Input';
 import TeamList from './TeamList';
 import { api } from '~/utils/api';
+
+function useSearchQuery() {
+  const router = useRouter();
+  const initialQuery = (router.query.q as string | undefined) ?? '';
+  const [searchQuery, setSearchQuery] = useState(initialQuery);
+  const [debouncedSearchQuery, setDebouncedSearchQuery] =
+    useState(initialQuery);
+
+  useDebounce(
+    () => {
+      if (debouncedSearchQuery !== searchQuery) {
+        setDebouncedSearchQuery(searchQuery);
+      }
+    },
+    500,
+    [searchQuery]
+  );
+
+  // update the URL with debouncedSearchQuery
+  useEffect(() => {
+    if (router.query.q !== debouncedSearchQuery) {
+      void router.replace({
+        query: { ...router.query, q: debouncedSearchQuery || undefined },
+      });
+    }
+  }, [debouncedSearchQuery, router, router.query]);
+
+  // update searchQuery when the URL changes
+  useEffect(() => {
+    if (router.query.q !== searchQuery) {
+      setSearchQuery((router.query.q as string | undefined) ?? '');
+    }
+    // Disabled due to causing of infinite loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router.query.q]);
+
+  return { searchQuery: debouncedSearchQuery, setSearchQuery };
+}
 
 function useScrollPosition() {
   const [scrollPosition, setScrollPosition] = useState(0);
@@ -14,7 +54,6 @@ function useScrollPosition() {
       document.documentElement.clientHeight;
     const winScroll =
       document.body.scrollTop || document.documentElement.scrollTop;
-
     const scrolled = (winScroll / height) * 100;
 
     setScrollPosition(scrolled);
@@ -32,9 +71,11 @@ function useScrollPosition() {
 }
 
 function useTeamQuery() {
+  const { searchQuery, setSearchQuery } = useSearchQuery();
   const { data, ...rest } = api.team.listWithFilter.useInfiniteQuery(
     {
       limit: 32,
+      searchQuery,
     },
     {
       getNextPageParam: lastPage => lastPage.nextCursor,
@@ -43,19 +84,27 @@ function useTeamQuery() {
   );
 
   return {
+    searchQuery,
+    setSearchQuery,
     data: data?.pages?.flatMap(page => page.teams) ?? [],
     ...rest,
   };
 }
 
 export default function Explore() {
-  const [searchQuery, setSearchQuery] = useState('');
-  const { data, error, status, hasNextPage, isFetching, fetchNextPage } =
-    useTeamQuery();
+  const {
+    searchQuery,
+    setSearchQuery,
+    data,
+    error,
+    status,
+    hasNextPage,
+    isFetching,
+    fetchNextPage,
+  } = useTeamQuery();
   const { scrollPosition } = useScrollPosition();
 
   useEffect(() => {
-    console.log(scrollPosition);
     if (scrollPosition > 90 && hasNextPage && !isFetching) {
       void fetchNextPage();
     }
@@ -69,7 +118,7 @@ export default function Explore() {
             type='text'
             placeholder='Search'
             className='h-9 w-full placeholder:text-sm placeholder:font-medium sm:w-64'
-            value={searchQuery}
+            defaultValue={searchQuery}
             onChange={e => setSearchQuery(e.target.value)}
           />
           <SearchIcon className='absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400' />
@@ -79,9 +128,6 @@ export default function Explore() {
         </Button>
       </div>
       <TeamList data={data} error={error} status={status} />
-      <p className='text-center text-slate-300'>
-        There are no more teams to load.
-      </p>
     </>
   );
 }

--- a/src/core/dashboard/teams/Explore.tsx
+++ b/src/core/dashboard/teams/Explore.tsx
@@ -1,0 +1,43 @@
+import { FilterIcon, SearchIcon } from 'lucide-react';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { Button } from '~/components/ui/Button';
+import { Input } from '~/components/ui/Input';
+import { useDebounce } from '~/hooks/useDebounce';
+
+export default function Explore() {
+  const [query, setQuery] = useState('');
+
+  const router = useRouter();
+
+  useDebounce(
+    () => {
+      void router.replace({
+        query: { ...router.query, q: query },
+      });
+    },
+    500,
+    [query]
+  );
+
+  return (
+    <>
+      <div className='flex w-full gap-4 self-start'>
+        <div className='relative grow sm:grow-0'>
+          <Input
+            type='text'
+            placeholder='Search'
+            className='h-9 w-full placeholder:text-sm placeholder:font-medium sm:w-64'
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+          />
+          <SearchIcon className='absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400' />
+        </div>
+        <Button variant='ghost' className='h-9 w-9 px-0'>
+          <FilterIcon className='h-[18px] w-[18px] text-slate-50' />
+        </Button>
+      </div>
+      {/* <TeamList /> */}
+    </>
+  );
+}

--- a/src/core/dashboard/teams/Explore.tsx
+++ b/src/core/dashboard/teams/Explore.tsx
@@ -1,24 +1,65 @@
 import { FilterIcon, SearchIcon } from 'lucide-react';
-import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '~/components/ui/Button';
 import { Input } from '~/components/ui/Input';
-import { useDebounce } from '~/hooks/useDebounce';
+import TeamList from './TeamList';
+import { api } from '~/utils/api';
+
+function useScrollPosition() {
+  const [scrollPosition, setScrollPosition] = useState(0);
+
+  function handleScroll() {
+    const height =
+      document.documentElement.scrollHeight -
+      document.documentElement.clientHeight;
+    const winScroll =
+      document.body.scrollTop || document.documentElement.scrollTop;
+
+    const scrolled = (winScroll / height) * 100;
+
+    setScrollPosition(scrolled);
+  }
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  return { scrollPosition };
+}
+
+function useTeamQuery() {
+  const { data, ...rest } = api.team.listWithFilter.useInfiniteQuery(
+    {
+      limit: 32,
+    },
+    {
+      getNextPageParam: lastPage => lastPage.nextCursor,
+      keepPreviousData: true,
+    }
+  );
+
+  return {
+    data: data?.pages?.flatMap(page => page.teams) ?? [],
+    ...rest,
+  };
+}
 
 export default function Explore() {
-  const [query, setQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const { data, error, status, hasNextPage, isFetching, fetchNextPage } =
+    useTeamQuery();
+  const { scrollPosition } = useScrollPosition();
 
-  const router = useRouter();
-
-  useDebounce(
-    () => {
-      void router.replace({
-        query: { ...router.query, q: query },
-      });
-    },
-    500,
-    [query]
-  );
+  useEffect(() => {
+    console.log(scrollPosition);
+    if (scrollPosition > 90 && hasNextPage && !isFetching) {
+      void fetchNextPage();
+    }
+  }, [scrollPosition, fetchNextPage, hasNextPage, isFetching]);
 
   return (
     <>
@@ -28,8 +69,8 @@ export default function Explore() {
             type='text'
             placeholder='Search'
             className='h-9 w-full placeholder:text-sm placeholder:font-medium sm:w-64'
-            value={query}
-            onChange={e => setQuery(e.target.value)}
+            value={searchQuery}
+            onChange={e => setSearchQuery(e.target.value)}
           />
           <SearchIcon className='absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400' />
         </div>
@@ -37,7 +78,10 @@ export default function Explore() {
           <FilterIcon className='h-[18px] w-[18px] text-slate-50' />
         </Button>
       </div>
-      {/* <TeamList /> */}
+      <TeamList data={data} error={error} status={status} />
+      <p className='text-center text-slate-300'>
+        There are no more teams to load.
+      </p>
     </>
   );
 }

--- a/src/core/dashboard/teams/Team.tsx
+++ b/src/core/dashboard/teams/Team.tsx
@@ -23,7 +23,7 @@ export default function Team({ team }: { team: Team }) {
   }, [team.members, team.rosters]);
 
   return (
-    <div className='flex w-full items-center gap-4 rounded-md bg-slate-900 p-4 ring-1 ring-slate-800'>
+    <div className='flex w-full items-center gap-4 rounded-md bg-slate-900 p-4'>
       <Avatar>
         <AvatarImage
           src={team.profilePicture ?? ''}

--- a/src/core/dashboard/teams/Team.tsx
+++ b/src/core/dashboard/teams/Team.tsx
@@ -5,7 +5,7 @@ import { capitalize } from '~/lib/utils';
 import { type RouterOutputs } from '~/utils/api';
 import TeamDropdown from './TeamDropdown';
 
-type Team = RouterOutputs['team']['list'][number];
+type Team = RouterOutputs['team']['listMemberOf'][number];
 type Role = $Enums.RosterRole | Exclude<$Enums.TeamRole, 'member'>;
 
 export default function Team({ team }: { team: Team }) {

--- a/src/core/dashboard/teams/TeamDropdown.tsx
+++ b/src/core/dashboard/teams/TeamDropdown.tsx
@@ -21,8 +21,9 @@ import {
 import { Input } from '~/components/ui/Input';
 import { cn } from '~/lib/utils';
 import { type RouterOutputs, api } from '~/utils/api';
+import { useNewTeam } from './new-team/newTeamStore';
 
-type Team = RouterOutputs['team']['list'][number];
+type Team = RouterOutputs['team']['listMemberOf'][number];
 type Role = $Enums.RosterRole | Exclude<$Enums.TeamRole, 'member'>;
 
 export default function TeamDropdown({
@@ -35,6 +36,8 @@ export default function TeamDropdown({
   className?: string;
 }) {
   const [menuOpened, setMenuOpened] = useState(false);
+  const { setSheetOpened, setEditMode, setEditModeTeamId, setData } =
+    useNewTeam();
 
   return (
     <DropdownMenu open={menuOpened} onOpenChange={setMenuOpened} modal={false}>
@@ -48,15 +51,20 @@ export default function TeamDropdown({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end' className='w-56'>
-        {/* <DropdownMenuLabel>Setups</DropdownMenuLabel>
-        <DropdownMenuGroup>
-          <AddSetupDialog event={event} />
-          <ViewSetupsDialog event={event} />
-        </DropdownMenuGroup> */}
-        {/* <DropdownMenuSeparator /> */}
         <DropdownMenuLabel>Manage team</DropdownMenuLabel>
         <DropdownMenuGroup>
-          <DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => {
+              setSheetOpened(true);
+              setEditMode(true);
+              setEditModeTeamId(team.id);
+              setData({
+                ...team,
+                profilePicture: undefined,
+                password: '',
+              });
+            }}
+          >
             <PencilIcon className='mr-2 h-4 w-4' />
             <span>Edit team</span>
           </DropdownMenuItem>

--- a/src/core/dashboard/teams/TeamDropdown.tsx
+++ b/src/core/dashboard/teams/TeamDropdown.tsx
@@ -19,7 +19,7 @@ import {
   DropdownMenuTrigger,
 } from '~/components/ui/DropdownMenu';
 import { Input } from '~/components/ui/Input';
-import { cn, urlToFile } from '~/lib/utils';
+import { cn } from '~/lib/utils';
 import { type RouterOutputs, api } from '~/utils/api';
 import { useNewTeam } from './new-team/newTeamStore';
 
@@ -39,24 +39,16 @@ export default function TeamDropdown({
   const { setSheetOpened, setEditMode, setEditModeTeamId, setData } =
     useNewTeam();
 
-  const handleEditTeam = async () => {
+  const handleEditTeam = () => {
     setSheetOpened(true);
     setEditMode(true);
     setEditModeTeamId(team.id);
-
-    let profilePictureFile: File | null = null;
-    if (team.profilePicture) {
-      profilePictureFile = await urlToFile({
-        url: team.profilePicture,
-        filename: 'profilePicture.png',
-      });
-    }
 
     setData({
       name: team.name,
       abbreviation: team.abbreviation,
       password: '',
-      profilePicture: profilePictureFile,
+      profilePicture: null,
     });
   };
 

--- a/src/core/dashboard/teams/TeamDropdown.tsx
+++ b/src/core/dashboard/teams/TeamDropdown.tsx
@@ -19,7 +19,7 @@ import {
   DropdownMenuTrigger,
 } from '~/components/ui/DropdownMenu';
 import { Input } from '~/components/ui/Input';
-import { cn } from '~/lib/utils';
+import { cn, urlToFile } from '~/lib/utils';
 import { type RouterOutputs, api } from '~/utils/api';
 import { useNewTeam } from './new-team/newTeamStore';
 
@@ -39,6 +39,27 @@ export default function TeamDropdown({
   const { setSheetOpened, setEditMode, setEditModeTeamId, setData } =
     useNewTeam();
 
+  const handleEditTeam = async () => {
+    setSheetOpened(true);
+    setEditMode(true);
+    setEditModeTeamId(team.id);
+
+    let profilePictureFile: File | null = null;
+    if (team.profilePicture) {
+      profilePictureFile = await urlToFile({
+        url: team.profilePicture,
+        filename: 'profilePicture.png',
+      });
+    }
+
+    setData({
+      name: team.name,
+      abbreviation: team.abbreviation,
+      password: '',
+      profilePicture: profilePictureFile,
+    });
+  };
+
   return (
     <DropdownMenu open={menuOpened} onOpenChange={setMenuOpened} modal={false}>
       <DropdownMenuTrigger asChild>
@@ -53,18 +74,7 @@ export default function TeamDropdown({
       <DropdownMenuContent align='end' className='w-56'>
         <DropdownMenuLabel>Manage team</DropdownMenuLabel>
         <DropdownMenuGroup>
-          <DropdownMenuItem
-            onClick={() => {
-              setSheetOpened(true);
-              setEditMode(true);
-              setEditModeTeamId(team.id);
-              setData({
-                ...team,
-                profilePicture: undefined,
-                password: '',
-              });
-            }}
-          >
+          <DropdownMenuItem onClick={handleEditTeam}>
             <PencilIcon className='mr-2 h-4 w-4' />
             <span>Edit team</span>
           </DropdownMenuItem>

--- a/src/core/dashboard/teams/TeamList.tsx
+++ b/src/core/dashboard/teams/TeamList.tsx
@@ -1,5 +1,5 @@
 import { useToast } from '~/components/ui/useToast';
-import { type RouterOutputs, api } from '~/utils/api';
+import { type RouterOutputs } from '~/utils/api';
 import Team from './Team';
 import { Button } from '~/components/ui/Button';
 import { useNewTeam } from './new-team/newTeamStore';
@@ -19,32 +19,6 @@ export default function TeamList({
   error: Omit<TRPCError, 'code' | 'name'> | null;
   addTeamButton?: boolean;
 }) {
-  // const [page, setPage] = useState(0);
-
-  // const {
-  //   data: teams,
-  //   status,
-  //   error,
-  //   fetchNextPage,
-  // } = api.team.get.useInfiniteQuery(
-  //   {
-  //     limit: 4,
-  //   },
-  //   {
-  //     getNextPageParam: lastPage => lastPage.nextCursor,
-  //   }
-  // );
-
-  // async function handleFetchNextPage() {
-  //   await fetchNextPage();
-  //   setPage(prev => prev + 1);
-  // }
-
-  // function handleFetchPrevPage() {
-  //   setPage(prev => prev - 1);
-  // }
-
-  // const { data: teams, status, error } = api.team.listMemberOf.useQuery();
   const setNewTeamFormOpened = useNewTeam(s => s.setSheetOpened);
   const { toast } = useToast();
 

--- a/src/core/dashboard/teams/TeamList.tsx
+++ b/src/core/dashboard/teams/TeamList.tsx
@@ -7,7 +7,11 @@ import { useNewTeam } from './new-team/newTeamStore';
 import { PlusIcon } from 'lucide-react';
 import { Skeleton } from '~/components/ui/Skeleton';
 
-export default function TeamList() {
+export default function TeamList({
+  addTeamButton = false,
+}: {
+  addTeamButton?: boolean;
+}) {
   const { data: teams, status, error } = api.team.list.useQuery();
   const setNewTeamFormOpened = useNewTeam(s => s.setSheetOpened);
 
@@ -66,13 +70,15 @@ export default function TeamList() {
           {teams.map(team => (
             <Team key={team.id} team={team} />
           ))}
-          <button
-            className='flex min-h-[5rem] items-center justify-center rounded-md text-slate-300 ring-1 ring-slate-800'
-            aria-label='New team'
-            onClick={() => setNewTeamFormOpened(true)}
-          >
-            <PlusIcon />
-          </button>
+          {addTeamButton ? (
+            <button
+              className='flex min-h-[5rem] items-center justify-center rounded-md text-slate-300 ring-1 ring-slate-800'
+              aria-label='New team'
+              onClick={() => setNewTeamFormOpened(true)}
+            >
+              <PlusIcon />
+            </button>
+          ) : null}
         </div>
       ) : (
         <div className='flex flex-col items-center gap-1 text-slate-300'>

--- a/src/core/dashboard/teams/TeamList.tsx
+++ b/src/core/dashboard/teams/TeamList.tsx
@@ -1,30 +1,52 @@
-import { useEffect } from 'react';
 import { useToast } from '~/components/ui/useToast';
-import { api } from '~/utils/api';
+import { type RouterOutputs, api } from '~/utils/api';
 import Team from './Team';
 import { Button } from '~/components/ui/Button';
 import { useNewTeam } from './new-team/newTeamStore';
 import { PlusIcon } from 'lucide-react';
 import { Skeleton } from '~/components/ui/Skeleton';
+import { type QueryStatus } from '@tanstack/react-query';
+import { type TRPCError } from '@trpc/server';
 
 export default function TeamList({
+  data: teams,
+  status,
+  error,
   addTeamButton = false,
 }: {
+  data: RouterOutputs['team']['listMemberOf'] | undefined;
+  status: QueryStatus;
+  error: Omit<TRPCError, 'code' | 'name'> | null;
   addTeamButton?: boolean;
 }) {
-  const { data: teams, status, error } = api.team.list.useQuery();
+  // const [page, setPage] = useState(0);
+
+  // const {
+  //   data: teams,
+  //   status,
+  //   error,
+  //   fetchNextPage,
+  // } = api.team.get.useInfiniteQuery(
+  //   {
+  //     limit: 4,
+  //   },
+  //   {
+  //     getNextPageParam: lastPage => lastPage.nextCursor,
+  //   }
+  // );
+
+  // async function handleFetchNextPage() {
+  //   await fetchNextPage();
+  //   setPage(prev => prev + 1);
+  // }
+
+  // function handleFetchPrevPage() {
+  //   setPage(prev => prev - 1);
+  // }
+
+  // const { data: teams, status, error } = api.team.listMemberOf.useQuery();
   const setNewTeamFormOpened = useNewTeam(s => s.setSheetOpened);
-
   const { toast } = useToast();
-
-  useEffect(() => {
-    if (status !== 'error') return;
-    toast({
-      variant: 'destructive',
-      title: 'An error occured',
-      description: error.message,
-    });
-  }, [error?.message, status, toast]);
 
   if (status === 'loading') {
     return (
@@ -54,6 +76,12 @@ export default function TeamList({
   }
 
   if (status === 'error') {
+    toast({
+      variant: 'destructive',
+      title: 'An error occured',
+      description: error?.message,
+    });
+
     return (
       <section className='flex w-full flex-col'>
         <p className='text-center text-slate-300 lg:text-left'>
@@ -65,9 +93,9 @@ export default function TeamList({
 
   return (
     <section>
-      {teams.length > 0 ? (
+      {teams?.length !== 0 ? (
         <div className='grid grid-cols-1 gap-4 md:grid-cols-[repeat(auto-fill,_417px)]'>
-          {teams.map(team => (
+          {teams?.map(team => (
             <Team key={team.id} team={team} />
           ))}
           {addTeamButton ? (

--- a/src/core/dashboard/teams/YourTeams.tsx
+++ b/src/core/dashboard/teams/YourTeams.tsx
@@ -1,14 +1,8 @@
 import { api } from '~/utils/api';
 import TeamList from './TeamList';
-import NewTeam from './new-team/NewTeam';
 
 export default function YourTeams() {
   const { data, status, error } = api.team.listMemberOf.useQuery();
 
-  return (
-    <>
-      <TeamList data={data} status={status} error={error} addTeamButton />
-      <NewTeam />
-    </>
-  );
+  return <TeamList data={data} status={status} error={error} addTeamButton />;
 }

--- a/src/core/dashboard/teams/YourTeams.tsx
+++ b/src/core/dashboard/teams/YourTeams.tsx
@@ -1,0 +1,14 @@
+import { api } from '~/utils/api';
+import TeamList from './TeamList';
+import NewTeam from './new-team/NewTeam';
+
+export default function YourTeams() {
+  const { data, status, error } = api.team.listMemberOf.useQuery();
+
+  return (
+    <>
+      <TeamList data={data} status={status} error={error} addTeamButton />
+      <NewTeam />
+    </>
+  );
+}

--- a/src/core/dashboard/teams/new-team/NewTeam.tsx
+++ b/src/core/dashboard/teams/new-team/NewTeam.tsx
@@ -11,7 +11,7 @@ import { useNewTeam } from './newTeamStore';
 import { Button } from '~/components/ui/Button';
 import { PlusIcon, UploadIcon } from 'lucide-react';
 import { z } from 'zod';
-import { useForm } from 'react-hook-form';
+import { type UseFormReturn, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   Form,
@@ -26,7 +26,7 @@ import { Input } from '~/components/ui/Input';
 import { uploadFiles } from '~/utils/uploadthing';
 import { useState, useEffect } from 'react';
 import { api } from '~/utils/api';
-import { useToast } from '~/components/ui/useToast';
+import { toast, useToast } from '~/components/ui/useToast';
 import { UploadThingError } from 'uploadthing/server';
 import { useRouter } from 'next/router';
 
@@ -43,10 +43,7 @@ export const newTeamSchema = z.object({
     .string()
     .min(1, 'Abbreviation is required.')
     .length(3, 'Abbreviation must be 3 characters long.'),
-  password: z
-    .string()
-    .min(1, 'Join password is required.')
-    .min(4, 'Join password must be at least 4 characters long.'),
+  password: z.string().optional(),
   profilePicture: z
     .custom<File | null>()
     .optional()
@@ -60,6 +57,56 @@ export const newTeamSchema = z.object({
     ),
 });
 
+function useTeamMutations({
+  form,
+}: {
+  form: UseFormReturn<z.infer<typeof newTeamSchema>>;
+}) {
+  const { setSheetOpened, editMode, reset } = useNewTeam();
+
+  const utils = api.useContext();
+
+  async function onSuccess() {
+    await utils.team.invalidate();
+    form.reset();
+    setSheetOpened(false);
+    toast({
+      variant: 'default',
+      title: 'Success!',
+      description: `A team has successfully been ${
+        editMode ? 'edited' : 'created'
+      }.`,
+    });
+    reset();
+  }
+
+  function onError({ errorMessage }: { errorMessage: string }) {
+    toast({
+      variant: 'destructive',
+      title: 'An error occured.',
+      description: errorMessage,
+    });
+  }
+
+  const { mutateAsync: createTeam, isLoading: isCreateLoading } =
+    api.team.create.useMutation({
+      onSuccess,
+      onError: err => onError({ errorMessage: err.message }),
+    });
+
+  const { mutateAsync: editTeam, isLoading: isEditLoading } =
+    api.team.edit.useMutation({
+      onSuccess,
+      onError: err => onError({ errorMessage: err.message }),
+    });
+
+  return {
+    createTeam,
+    editTeam,
+    isLoading: isCreateLoading || isEditLoading,
+  };
+}
+
 export default function NewTeam() {
   const router = useRouter();
   const {
@@ -68,9 +115,7 @@ export default function NewTeam() {
     data,
     setData,
     editMode,
-    setEditMode,
     editModeTeamId,
-    setEditModeTeamId,
     reset,
   } = useNewTeam();
   const { toast } = useToast();
@@ -78,7 +123,17 @@ export default function NewTeam() {
   const [isImageUploading, setIsImageUploading] = useState(false);
 
   const form = useForm<z.infer<typeof newTeamSchema>>({
-    resolver: zodResolver(newTeamSchema),
+    resolver: zodResolver(
+      newTeamSchema.superRefine(({ password }, ctx) => {
+        if (!editMode && (!password || password.length < 4)) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['password'],
+            message: 'Join password must be at least 4 characters long.',
+          });
+        }
+      })
+    ),
     defaultValues: {
       name: data?.name ?? '',
       abbreviation: data?.abbreviation ?? '',
@@ -87,41 +142,38 @@ export default function NewTeam() {
     },
   });
 
+  const { createTeam, editTeam, isLoading } = useTeamMutations({ form });
+
   useEffect(() => {
     if (editMode && data) {
-      console.log(data.profilePicture);
       form.reset({
         name: data.name,
         abbreviation: data.abbreviation,
         password: data.password,
         profilePicture: data.profilePicture ?? null,
       });
+    } else if (!editMode) {
+      form.reset({
+        name: '',
+        abbreviation: '',
+        password: '',
+        profilePicture: null,
+      });
     }
   }, [editMode, data, form]);
 
-  const utils = api.useContext();
-  const { mutate: createTeam, isLoading } = api.team.create.useMutation({
-    onSuccess: async () => {
-      await utils.team.invalidate();
-      form.reset();
-      setSheetOpened(false);
-      reset();
-      toast({
-        variant: 'default',
-        title: 'Success!',
-        description: 'A team has successfully been created.',
+  useEffect(() => {
+    if (!sheetOpened) {
+      form.reset({
+        name: '',
+        abbreviation: '',
+        password: '',
+        profilePicture: null,
       });
-    },
-    onError: err => {
-      toast({
-        variant: 'destructive',
-        title: 'An error occured.',
-        description: err.message,
-      });
-    },
-  });
+    }
+  }, [sheetOpened, form]);
 
-  function onSubmit(values: z.infer<typeof newTeamSchema>) {
+  async function onSubmit(values: z.infer<typeof newTeamSchema>) {
     setData(values);
 
     if (values.profilePicture) {
@@ -129,12 +181,22 @@ export default function NewTeam() {
       uploadFiles('imageUploader', {
         files: [values.profilePicture],
       })
-        .then(res => {
-          createTeam({
-            ...values,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            profilePicture: res[0]!.url,
-          });
+        .then(async res => {
+          editMode
+            ? await editTeam({
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                teamId: editModeTeamId!,
+                ...values,
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                profilePicture: res[0]!.url,
+              })
+            : await createTeam({
+                ...values,
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                password: values.password!,
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                profilePicture: res[0]!.url,
+              });
         })
         .catch(err => {
           if (err instanceof UploadThingError) {
@@ -149,7 +211,21 @@ export default function NewTeam() {
       return;
     }
 
-    createTeam({ ...values, profilePicture: undefined });
+    if (editMode) {
+      await editTeam({
+        ...values,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        teamId: editModeTeamId!,
+        profilePicture: undefined,
+      });
+    } else {
+      await createTeam({
+        ...values,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        password: values.password!,
+        profilePicture: undefined,
+      });
+    }
   }
 
   return (
@@ -208,28 +284,32 @@ export default function NewTeam() {
                   </FormItem>
                 )}
               />
-              <FormField
-                control={form.control}
-                name='password'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Join password</FormLabel>
-                    <FormControl className='w-[278px]'>
-                      <Input type='password' {...field} />
-                    </FormControl>
-                    <FormDescription className='w-[278px]'>
-                      This password will allow members to join your team.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
+              {!editMode ? (
+                <FormField
+                  control={form.control}
+                  name='password'
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Join password</FormLabel>
+                      <FormControl className='w-[278px]'>
+                        <Input type='password' {...field} />
+                      </FormControl>
+                      <FormDescription className='w-[278px]'>
+                        This password will allow members to join your team.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ) : null}
               <FormField
                 control={form.control}
                 name='profilePicture'
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Team picture (optional)</FormLabel>
+                    <FormLabel>
+                      Team picture {!editMode && '(optional)'}
+                    </FormLabel>
                     <FormControl>
                       <Input
                         type='file'

--- a/src/core/dashboard/teams/new-team/NewTeam.tsx
+++ b/src/core/dashboard/teams/new-team/NewTeam.tsx
@@ -23,12 +23,11 @@ import {
   FormMessage,
 } from '~/components/ui/Form';
 import { Input } from '~/components/ui/Input';
-import { uploadFiles } from '~/utils/uploadthing';
-import { useState, useEffect } from 'react';
+import { useEffect } from 'react';
 import { api } from '~/utils/api';
-import { toast, useToast } from '~/components/ui/useToast';
-import { UploadThingError } from 'uploadthing/server';
+import { useToast } from '~/components/ui/useToast';
 import { useRouter } from 'next/router';
+import { useImageUpload } from '~/hooks/useImageUpload';
 
 const acceptedImageTypes = [
   'image/jpeg',
@@ -63,6 +62,7 @@ function useTeamMutations({
   form: UseFormReturn<z.infer<typeof newTeamSchema>>;
 }) {
   const { setSheetOpened, editMode, reset } = useNewTeam();
+  const { toast } = useToast();
 
   const utils = api.useContext();
 
@@ -118,9 +118,8 @@ export default function NewTeam() {
     editModeTeamId,
     reset,
   } = useNewTeam();
-  const { toast } = useToast();
 
-  const [isImageUploading, setIsImageUploading] = useState(false);
+  const { uploadImage, isImageUploading } = useImageUpload();
 
   const form = useForm<z.infer<typeof newTeamSchema>>({
     resolver: zodResolver(
@@ -175,40 +174,12 @@ export default function NewTeam() {
 
   async function onSubmit(values: z.infer<typeof newTeamSchema>) {
     setData(values);
+    let profilePicture: string | undefined = undefined;
 
     if (values.profilePicture) {
-      setIsImageUploading(true);
-      uploadFiles('imageUploader', {
-        files: [values.profilePicture],
-      })
-        .then(async res => {
-          editMode
-            ? await editTeam({
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                teamId: editModeTeamId!,
-                ...values,
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                profilePicture: res[0]!.url,
-              })
-            : await createTeam({
-                ...values,
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                password: values.password!,
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                profilePicture: res[0]!.url,
-              });
-        })
-        .catch(err => {
-          if (err instanceof UploadThingError) {
-            toast({
-              variant: 'destructive',
-              title: 'An error occured while uploading the image.',
-              description: err.message,
-            });
-          }
-        });
-      setIsImageUploading(false);
-      return;
+      await uploadImage(values.profilePicture, ({ url }) => {
+        profilePicture = url;
+      });
     }
 
     if (editMode) {
@@ -216,14 +187,14 @@ export default function NewTeam() {
         ...values,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         teamId: editModeTeamId!,
-        profilePicture: undefined,
+        profilePicture,
       });
     } else {
       await createTeam({
         ...values,
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         password: values.password!,
-        profilePicture: undefined,
+        profilePicture,
       });
     }
   }

--- a/src/core/dashboard/teams/new-team/NewTeam.tsx
+++ b/src/core/dashboard/teams/new-team/NewTeam.tsx
@@ -24,7 +24,7 @@ import {
 } from '~/components/ui/Form';
 import { Input } from '~/components/ui/Input';
 import { uploadFiles } from '~/utils/uploadthing';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { api } from '~/utils/api';
 import { useToast } from '~/components/ui/useToast';
 import { UploadThingError } from 'uploadthing/server';
@@ -62,7 +62,17 @@ export const newTeamSchema = z.object({
 
 export default function NewTeam() {
   const router = useRouter();
-  const { setSheetOpened, sheetOpened, data, setData } = useNewTeam();
+  const {
+    setSheetOpened,
+    sheetOpened,
+    data,
+    setData,
+    editMode,
+    setEditMode,
+    editModeTeamId,
+    setEditModeTeamId,
+    reset,
+  } = useNewTeam();
   const { toast } = useToast();
 
   const [isImageUploading, setIsImageUploading] = useState(false);
@@ -77,13 +87,25 @@ export default function NewTeam() {
     },
   });
 
+  useEffect(() => {
+    if (editMode && data) {
+      console.log(data.profilePicture);
+      form.reset({
+        name: data.name,
+        abbreviation: data.abbreviation,
+        password: data.password,
+        profilePicture: data.profilePicture ?? null,
+      });
+    }
+  }, [editMode, data, form]);
+
   const utils = api.useContext();
   const { mutate: createTeam, isLoading } = api.team.create.useMutation({
     onSuccess: async () => {
       await utils.team.invalidate();
-      setData(null);
       form.reset();
       setSheetOpened(false);
+      reset();
       toast({
         variant: 'default',
         title: 'Success!',
@@ -144,11 +166,17 @@ export default function NewTeam() {
           </Button>
         ) : null}
       </SheetTrigger>
-      <SheetContent className='w-full border-0 ring-1 ring-slate-900'>
+      <SheetContent
+        className='w-full border-0 ring-1 ring-slate-900'
+        onClose={reset}
+      >
         <SheetHeader>
-          <SheetTitle className='text-3xl'>Create team</SheetTitle>
+          <SheetTitle className='text-3xl'>
+            {editMode ? 'Edit' : 'Create'} team
+          </SheetTitle>
           <SheetDescription>
-            Fill team data, click create when you&apos;re ready.
+            Fill team data, click {editMode ? 'edit' : 'create'} when
+            you&apos;re ready.
           </SheetDescription>
         </SheetHeader>
         <Form {...form}>
@@ -236,7 +264,7 @@ export default function NewTeam() {
             </div>
             <SheetFooter className='mx-auto mt-auto w-[278px]'>
               <Button type='submit' loading={isImageUploading || isLoading}>
-                Create team
+                {editMode ? 'Edit' : 'Create'} team
               </Button>
             </SheetFooter>
           </form>

--- a/src/core/dashboard/teams/new-team/NewTeam.tsx
+++ b/src/core/dashboard/teams/new-team/NewTeam.tsx
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { api } from '~/utils/api';
 import { useToast } from '~/components/ui/useToast';
 import { UploadThingError } from 'uploadthing/server';
+import { useRouter } from 'next/router';
 
 const acceptedImageTypes = [
   'image/jpeg',
@@ -60,6 +61,7 @@ export const newTeamSchema = z.object({
 });
 
 export default function NewTeam() {
+  const router = useRouter();
   const { setSheetOpened, sheetOpened, data, setData } = useNewTeam();
   const { toast } = useToast();
 
@@ -131,14 +133,16 @@ export default function NewTeam() {
   return (
     <Sheet open={sheetOpened} onOpenChange={setSheetOpened}>
       <SheetTrigger asChild className='lg:hidden'>
-        <Button
-          variant='fab'
-          size='fab'
-          className='fixed bottom-24 right-4'
-          aria-label='Create team'
-        >
-          <PlusIcon />
-        </Button>
+        {(router.query.t as string | undefined) === 'your-teams' ? (
+          <Button
+            variant='fab'
+            size='fab'
+            className='fixed bottom-24 right-4'
+            aria-label='Create team'
+          >
+            <PlusIcon />
+          </Button>
+        ) : null}
       </SheetTrigger>
       <SheetContent className='w-full border-0 ring-1 ring-slate-900'>
         <SheetHeader>

--- a/src/core/dashboard/teams/new-team/NewTeam.tsx
+++ b/src/core/dashboard/teams/new-team/NewTeam.tsx
@@ -185,7 +185,7 @@ export default function NewTeam() {
                     <FormControl className='w-[278px]'>
                       <Input type='password' {...field} />
                     </FormControl>
-                    <FormDescription>
+                    <FormDescription className='w-[278px]'>
                       This password will allow members to join your team.
                     </FormDescription>
                     <FormMessage />
@@ -230,7 +230,7 @@ export default function NewTeam() {
                 )}
               />
             </div>
-            <SheetFooter className='mt-auto'>
+            <SheetFooter className='mx-auto mt-auto w-[278px]'>
               <Button type='submit' loading={isImageUploading || isLoading}>
                 Create team
               </Button>

--- a/src/core/dashboard/teams/new-team/newTeamStore.ts
+++ b/src/core/dashboard/teams/new-team/newTeamStore.ts
@@ -11,6 +11,7 @@ export const useNewTeam = create<{
   setEditMode: (editMode: boolean) => void;
   editModeTeamId: string | undefined;
   setEditModeTeamId: (id: string | undefined) => void;
+  reset: () => void;
 }>(set => ({
   sheetOpened: false,
   setSheetOpened: sheetOpened => set(() => ({ sheetOpened })),
@@ -20,4 +21,10 @@ export const useNewTeam = create<{
   setEditMode: editMode => set(() => ({ editMode })),
   editModeTeamId: undefined,
   setEditModeTeamId: editModeTeamId => set(() => ({ editModeTeamId })),
+  reset: () =>
+    set(() => ({
+      data: undefined,
+      editMode: false,
+      editModeTeamId: undefined,
+    })),
 }));

--- a/src/core/dashboard/teams/new-team/newTeamStore.ts
+++ b/src/core/dashboard/teams/new-team/newTeamStore.ts
@@ -7,9 +7,17 @@ export const useNewTeam = create<{
   setSheetOpened: (opened: boolean) => void;
   data: z.infer<typeof newTeamSchema> | undefined | null;
   setData: (data: z.infer<typeof newTeamSchema> | null) => void;
+  editMode: boolean;
+  setEditMode: (editMode: boolean) => void;
+  editModeTeamId: string | undefined;
+  setEditModeTeamId: (id: string | undefined) => void;
 }>(set => ({
   sheetOpened: false,
   setSheetOpened: sheetOpened => set(() => ({ sheetOpened })),
   data: undefined,
   setData: data => set(() => ({ data })),
+  editMode: false,
+  setEditMode: editMode => set(() => ({ editMode })),
+  editModeTeamId: undefined,
+  setEditModeTeamId: editModeTeamId => set(() => ({ editModeTeamId })),
 }));

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -24,6 +24,8 @@ export const env = createEnv({
     DISCORD_CLIENT_SECRET: z.string(),
     ENCRYPTION_IV: z.string().length(32),
     ENCRYPTION_KEY: z.string().length(64),
+    UPLOADTHING_SECRET: z.string(),
+    UPLOADTHING_APP_ID: z.string(),
   },
 
   /**
@@ -47,6 +49,8 @@ export const env = createEnv({
     DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
     ENCRYPTION_IV: process.env.ENCRYPTION_IV,
     ENCRYPTION_KEY: process.env.ENCRYPTION_KEY,
+    UPLOADTHING_SECRET: process.env.UPLOADTHING_SECRET,
+    UPLOADTHING_APP_ID: process.env.UPLOADTHING_APP_ID,
     // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
   },
   /**

--- a/src/hooks/useImageUpload.ts
+++ b/src/hooks/useImageUpload.ts
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { UploadThingError } from 'uploadthing/server';
+import { toast } from '~/components/ui/useToast';
+import { uploadFiles } from '~/utils/uploadthing';
+
+export function useImageUpload() {
+  const [isImageUploading, setIsImageUploading] = useState(false);
+
+  async function uploadImage(
+    file: File,
+    onSuccess: ({ url }: { url: string }) => void | Promise<void>
+  ) {
+    setIsImageUploading(true);
+    try {
+      const res = await uploadFiles('imageUploader', {
+        files: [file],
+      });
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      await onSuccess({ url: res[0]!.url });
+    } catch (err) {
+      if (err instanceof UploadThingError) {
+        toast({
+          variant: 'destructive',
+          title: 'An error occured while uploading the image.',
+          description: err.message,
+        });
+      }
+    } finally {
+      setIsImageUploading(false);
+    }
+  }
+
+  return {
+    isImageUploading,
+    uploadImage,
+  };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -128,3 +128,27 @@ export function getCalendarRowStyles({
     width: counter > 0 ? width : '100%',
   };
 }
+
+export async function urlToFile({
+  url,
+  filename,
+}: {
+  url: string;
+  filename: string;
+}) {
+  const mimeTypeMapping: { [key: string]: `image/${string}` } = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    webp: 'image/webp',
+  };
+
+  const res = await fetch(url);
+  const buffer = await res.arrayBuffer();
+
+  // extract the file extension from the URL
+  const extension = url.split('.').pop()?.toLowerCase() || '';
+  const mimeType = mimeTypeMapping[extension] || 'application/octet-stream';
+
+  return new File([buffer], filename, { type: mimeType });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -128,27 +128,3 @@ export function getCalendarRowStyles({
     width: counter > 0 ? width : '100%',
   };
 }
-
-export async function urlToFile({
-  url,
-  filename,
-}: {
-  url: string;
-  filename: string;
-}) {
-  const mimeTypeMapping: { [key: string]: `image/${string}` } = {
-    jpg: 'image/jpeg',
-    jpeg: 'image/jpeg',
-    png: 'image/png',
-    webp: 'image/webp',
-  };
-
-  const res = await fetch(url);
-  const buffer = await res.arrayBuffer();
-
-  // extract the file extension from the URL
-  const extension = url.split('.').pop()?.toLowerCase() || '';
-  const mimeType = mimeTypeMapping[extension] || 'application/octet-stream';
-
-  return new File([buffer], filename, { type: mimeType });
-}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { api } from '~/utils/api';
 import '~/styles/globals.css';
 import { DefaultSeo } from 'next-seo';
 import Navbar from '~/components/Navbar';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 const MyApp: AppType<{ session: Session | null }> = ({
   Component,
@@ -74,6 +75,7 @@ const MyApp: AppType<{ session: Session | null }> = ({
         <Navbar disabledOn={['/', '/login', '/welcome']} />
         <Component {...pageProps} />
       </div>
+      <ReactQueryDevtools />
     </SessionProvider>
   );
 };

--- a/src/pages/teams.tsx
+++ b/src/pages/teams.tsx
@@ -1,13 +1,17 @@
+import { FilterIcon, SearchIcon } from 'lucide-react';
 import { type GetServerSidePropsContext, type NextPage } from 'next';
 import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
+import { useState } from 'react';
 import { Button } from '~/components/ui/Button';
+import { Input } from '~/components/ui/Input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/Tabs';
 import { Toaster } from '~/components/ui/Toaster';
 import DashboardLayout from '~/core/dashboard/Layout';
 import TeamList from '~/core/dashboard/teams/TeamList';
 import NewTeam from '~/core/dashboard/teams/new-team/NewTeam';
 import { useNewTeam } from '~/core/dashboard/teams/new-team/newTeamStore';
+import { useDebounce } from '~/hooks/useDebounce';
 import { useProtectedRoute } from '~/hooks/useProtectedRoute';
 import { getServerAuthSession } from '~/server/auth';
 
@@ -20,11 +24,22 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 }
 
 const Teams: NextPage = () => {
-  const setNewTeamFormOpened = useNewTeam(s => s.setSheetOpened);
+  useProtectedRoute();
 
+  const setNewTeamFormOpened = useNewTeam(s => s.setSheetOpened);
   const router = useRouter();
 
-  useProtectedRoute();
+  const [query, setQuery] = useState('');
+
+  useDebounce(
+    () => {
+      void router.replace({
+        query: { ...router.query, q: query },
+      });
+    },
+    500,
+    [query]
+  );
 
   return (
     <>
@@ -52,7 +67,9 @@ const Teams: NextPage = () => {
                 (router.query.t as string | undefined) ?? 'your-teams'
               }
               className='space-y-4'
-              onValueChange={tab => router.replace(`?t=${tab}`)}
+              onValueChange={tab =>
+                router.replace({ query: { ...router.query, t: tab } })
+              }
             >
               <TabsList className='grid w-full max-w-[417px] grid-cols-2 bg-slate-900'>
                 <TabsTrigger value='your-teams'>Your teams</TabsTrigger>
@@ -61,7 +78,24 @@ const Teams: NextPage = () => {
               <TabsContent value='your-teams'>
                 <TeamList />
               </TabsContent>
-              <TabsContent value='explore'>explore tab</TabsContent>
+              <TabsContent value='explore' className='flex flex-col gap-4'>
+                <div className='flex gap-4 self-start'>
+                  <div className='relative'>
+                    <Input
+                      type='text'
+                      placeholder='Search'
+                      className='h-9 w-64 placeholder:text-sm placeholder:font-medium'
+                      value={query}
+                      onChange={e => setQuery(e.target.value)}
+                    />
+                    <SearchIcon className='absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400' />
+                  </div>
+                  <Button variant='ghost' className='h-9 w-9 px-0'>
+                    <FilterIcon className='h-[18px] w-[18px] text-slate-50' />
+                  </Button>
+                </div>
+                <TeamList />
+              </TabsContent>
             </Tabs>
           </div>
           <NewTeam />

--- a/src/pages/teams.tsx
+++ b/src/pages/teams.tsx
@@ -6,6 +6,7 @@ import { Button } from '~/components/ui/Button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/Tabs';
 import { Toaster } from '~/components/ui/Toaster';
 import DashboardLayout from '~/core/dashboard/Layout';
+import NewTeam from '~/core/dashboard/teams/new-team/NewTeam';
 import { useNewTeam } from '~/core/dashboard/teams/new-team/newTeamStore';
 import { useProtectedRoute } from '~/hooks/useProtectedRoute';
 import { getServerAuthSession } from '~/server/auth';
@@ -41,12 +42,14 @@ const Teams: NextPage = () => {
                   Manage, create and join teams.
                 </span>
               </div>
-              <Button
-                variant='primary'
-                onClick={() => setNewTeamFormOpened(true)}
-              >
-                New team
-              </Button>
+              {(router.query.t as string | undefined) === 'your-teams' ? (
+                <Button
+                  variant='primary'
+                  onClick={() => setNewTeamFormOpened(true)}
+                >
+                  New team
+                </Button>
+              ) : null}
             </div>
             <Tabs
               defaultValue={
@@ -72,6 +75,7 @@ const Teams: NextPage = () => {
                 </Suspense>
               </TabsContent>
             </Tabs>
+            <NewTeam />
           </div>
         </DashboardLayout>
       </div>

--- a/src/pages/teams.tsx
+++ b/src/pages/teams.tsx
@@ -2,7 +2,7 @@ import { FilterIcon, SearchIcon } from 'lucide-react';
 import { type GetServerSidePropsContext, type NextPage } from 'next';
 import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { Suspense, lazy, useState } from 'react';
 import { Button } from '~/components/ui/Button';
 import { Input } from '~/components/ui/Input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/Tabs';
@@ -14,6 +14,8 @@ import { useNewTeam } from '~/core/dashboard/teams/new-team/newTeamStore';
 import { useDebounce } from '~/hooks/useDebounce';
 import { useProtectedRoute } from '~/hooks/useProtectedRoute';
 import { getServerAuthSession } from '~/server/auth';
+
+const YourTeams = lazy(() => import('~/core/dashboard/teams/YourTeams'));
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const session = await getServerAuthSession(ctx);
@@ -76,8 +78,9 @@ const Teams: NextPage = () => {
                 <TabsTrigger value='explore'>Explore</TabsTrigger>
               </TabsList>
               <TabsContent value='your-teams'>
-                <TeamList addTeamButton />
-                <NewTeam />
+                <Suspense>
+                  <YourTeams />
+                </Suspense>
               </TabsContent>
               <TabsContent value='explore' className='flex flex-col gap-4'>
                 <div className='flex w-full gap-4 self-start'>
@@ -95,7 +98,7 @@ const Teams: NextPage = () => {
                     <FilterIcon className='h-[18px] w-[18px] text-slate-50' />
                   </Button>
                 </div>
-                <TeamList />
+                {/* <TeamList /> */}
               </TabsContent>
             </Tabs>
           </div>

--- a/src/pages/teams.tsx
+++ b/src/pages/teams.tsx
@@ -1,21 +1,17 @@
-import { FilterIcon, SearchIcon } from 'lucide-react';
 import { type GetServerSidePropsContext, type NextPage } from 'next';
 import { NextSeo } from 'next-seo';
 import { useRouter } from 'next/router';
-import { Suspense, lazy, useState } from 'react';
+import { Suspense, lazy } from 'react';
 import { Button } from '~/components/ui/Button';
-import { Input } from '~/components/ui/Input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/Tabs';
 import { Toaster } from '~/components/ui/Toaster';
 import DashboardLayout from '~/core/dashboard/Layout';
-import TeamList from '~/core/dashboard/teams/TeamList';
-import NewTeam from '~/core/dashboard/teams/new-team/NewTeam';
 import { useNewTeam } from '~/core/dashboard/teams/new-team/newTeamStore';
-import { useDebounce } from '~/hooks/useDebounce';
 import { useProtectedRoute } from '~/hooks/useProtectedRoute';
 import { getServerAuthSession } from '~/server/auth';
 
 const YourTeams = lazy(() => import('~/core/dashboard/teams/YourTeams'));
+const Explore = lazy(() => import('~/core/dashboard/teams/Explore'));
 
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const session = await getServerAuthSession(ctx);
@@ -30,18 +26,6 @@ const Teams: NextPage = () => {
 
   const setNewTeamFormOpened = useNewTeam(s => s.setSheetOpened);
   const router = useRouter();
-
-  const [query, setQuery] = useState('');
-
-  useDebounce(
-    () => {
-      void router.replace({
-        query: { ...router.query, q: query },
-      });
-    },
-    500,
-    [query]
-  );
 
   return (
     <>
@@ -83,22 +67,9 @@ const Teams: NextPage = () => {
                 </Suspense>
               </TabsContent>
               <TabsContent value='explore' className='flex flex-col gap-4'>
-                <div className='flex w-full gap-4 self-start'>
-                  <div className='relative grow sm:grow-0'>
-                    <Input
-                      type='text'
-                      placeholder='Search'
-                      className='h-9 w-full placeholder:text-sm placeholder:font-medium sm:w-64'
-                      value={query}
-                      onChange={e => setQuery(e.target.value)}
-                    />
-                    <SearchIcon className='absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400' />
-                  </div>
-                  <Button variant='ghost' className='h-9 w-9 px-0'>
-                    <FilterIcon className='h-[18px] w-[18px] text-slate-50' />
-                  </Button>
-                </div>
-                {/* <TeamList /> */}
+                <Suspense>
+                  <Explore />
+                </Suspense>
               </TabsContent>
             </Tabs>
           </div>

--- a/src/pages/teams.tsx
+++ b/src/pages/teams.tsx
@@ -76,15 +76,16 @@ const Teams: NextPage = () => {
                 <TabsTrigger value='explore'>Explore</TabsTrigger>
               </TabsList>
               <TabsContent value='your-teams'>
-                <TeamList />
+                <TeamList addTeamButton />
+                <NewTeam />
               </TabsContent>
               <TabsContent value='explore' className='flex flex-col gap-4'>
-                <div className='flex gap-4 self-start'>
-                  <div className='relative'>
+                <div className='flex w-full gap-4 self-start'>
+                  <div className='relative grow sm:grow-0'>
                     <Input
                       type='text'
                       placeholder='Search'
-                      className='h-9 w-64 placeholder:text-sm placeholder:font-medium'
+                      className='h-9 w-full placeholder:text-sm placeholder:font-medium sm:w-64'
                       value={query}
                       onChange={e => setQuery(e.target.value)}
                     />
@@ -98,7 +99,6 @@ const Teams: NextPage = () => {
               </TabsContent>
             </Tabs>
           </div>
-          <NewTeam />
         </DashboardLayout>
       </div>
     </>

--- a/src/pages/teams.tsx
+++ b/src/pages/teams.tsx
@@ -1,5 +1,6 @@
 import { type GetServerSidePropsContext, type NextPage } from 'next';
 import { NextSeo } from 'next-seo';
+import { useRouter } from 'next/router';
 import { Button } from '~/components/ui/Button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/Tabs';
 import { Toaster } from '~/components/ui/Toaster';
@@ -20,6 +21,8 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
 const Teams: NextPage = () => {
   const setNewTeamFormOpened = useNewTeam(s => s.setSheetOpened);
+
+  const router = useRouter();
 
   useProtectedRoute();
 
@@ -44,7 +47,13 @@ const Teams: NextPage = () => {
                 New team
               </Button>
             </div>
-            <Tabs defaultValue='your-teams' className='space-y-4'>
+            <Tabs
+              defaultValue={
+                (router.query.t as string | undefined) ?? 'your-teams'
+              }
+              className='space-y-4'
+              onValueChange={tab => router.replace(`?t=${tab}`)}
+            >
               <TabsList className='grid w-full max-w-[417px] grid-cols-2 bg-slate-900'>
                 <TabsTrigger value='your-teams'>Your teams</TabsTrigger>
                 <TabsTrigger value='explore'>Explore</TabsTrigger>

--- a/src/pages/teams.tsx
+++ b/src/pages/teams.tsx
@@ -1,6 +1,7 @@
 import { type GetServerSidePropsContext, type NextPage } from 'next';
 import { NextSeo } from 'next-seo';
 import { Button } from '~/components/ui/Button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '~/components/ui/Tabs';
 import { Toaster } from '~/components/ui/Toaster';
 import DashboardLayout from '~/core/dashboard/Layout';
 import TeamList from '~/core/dashboard/teams/TeamList';
@@ -43,7 +44,16 @@ const Teams: NextPage = () => {
                 New team
               </Button>
             </div>
-            <TeamList />
+            <Tabs defaultValue='your-teams' className='space-y-4'>
+              <TabsList className='grid w-full max-w-[417px] grid-cols-2 bg-slate-900'>
+                <TabsTrigger value='your-teams'>Your teams</TabsTrigger>
+                <TabsTrigger value='explore'>Explore</TabsTrigger>
+              </TabsList>
+              <TabsContent value='your-teams'>
+                <TeamList />
+              </TabsContent>
+              <TabsContent value='explore'>explore tab</TabsContent>
+            </Tabs>
           </div>
           <NewTeam />
         </DashboardLayout>

--- a/src/server/api/routers/team.ts
+++ b/src/server/api/routers/team.ts
@@ -100,7 +100,7 @@ export const teamRouter = createTRPCRouter({
       },
     });
   }),
-  get: protectedProcedure
+  listWithFilter: protectedProcedure
     .input(
       z.object({
         limit: z.number(),
@@ -115,6 +115,24 @@ export const teamRouter = createTRPCRouter({
         skip,
         cursor: cursor ? { id: cursor } : undefined,
         orderBy: { id: 'asc' },
+        select: {
+          id: true,
+          name: true,
+          abbreviation: true,
+          profilePicture: true,
+          members: {
+            where: { userId: ctx.session.user.id },
+            select: { role: true },
+          },
+          rosters: {
+            select: {
+              members: {
+                where: { userId: ctx.session.user.id },
+                select: { role: true },
+              },
+            },
+          },
+        },
       });
 
       let nextCursor: typeof cursor | undefined = undefined;

--- a/src/server/api/routers/team.ts
+++ b/src/server/api/routers/team.ts
@@ -104,13 +104,25 @@ export const teamRouter = createTRPCRouter({
     .input(
       z.object({
         limit: z.number(),
+        searchQuery: z.string().nullish(),
         cursor: z.string().nullish(),
         skip: z.number().optional(),
       })
     )
     .query(async ({ ctx, input }) => {
-      const { limit, skip, cursor } = input;
+      const { limit, skip, cursor, searchQuery } = input;
       const teams = await ctx.prisma.team.findMany({
+        where: {
+          OR: [
+            { name: { contains: searchQuery ?? '', mode: 'insensitive' } },
+            {
+              abbreviation: {
+                contains: searchQuery ?? '',
+                mode: 'insensitive',
+              },
+            },
+          ],
+        },
         take: limit + 1,
         skip,
         cursor: cursor ? { id: cursor } : undefined,

--- a/src/server/api/routers/team.ts
+++ b/src/server/api/routers/team.ts
@@ -77,7 +77,7 @@ export const teamRouter = createTRPCRouter({
         },
       });
     }),
-  list: protectedProcedure.query(async ({ ctx }) => {
+  listMemberOf: protectedProcedure.query(async ({ ctx }) => {
     return await ctx.prisma.team.findMany({
       where: { members: { some: { userId: ctx.session.user.id } } },
       select: {
@@ -100,6 +100,34 @@ export const teamRouter = createTRPCRouter({
       },
     });
   }),
+  get: protectedProcedure
+    .input(
+      z.object({
+        limit: z.number(),
+        cursor: z.string().nullish(),
+        skip: z.number().optional(),
+      })
+    )
+    .query(async ({ ctx, input }) => {
+      const { limit, skip, cursor } = input;
+      const teams = await ctx.prisma.team.findMany({
+        take: limit + 1,
+        skip,
+        cursor: cursor ? { id: cursor } : undefined,
+        orderBy: { id: 'asc' },
+      });
+
+      let nextCursor: typeof cursor | undefined = undefined;
+      if (teams.length > limit) {
+        const nextTeam = teams.pop();
+        nextCursor = nextTeam?.id;
+      }
+
+      return {
+        teams,
+        nextCursor,
+      };
+    }),
   delete: protectedProcedure
     .input(z.object({ teamId: z.string() }))
     .mutation(async ({ ctx, input }) => {

--- a/src/server/api/routers/team.ts
+++ b/src/server/api/routers/team.ts
@@ -167,8 +167,13 @@ export const teamRouter = createTRPCRouter({
   create: protectedProcedure
     .input(
       newTeamSchema
-        .omit({ profilePicture: true })
-        .and(z.object({ profilePicture: z.string().optional() }))
+        .omit({ profilePicture: true, password: true })
+        .and(
+          z.object({
+            password: z.string(),
+            profilePicture: z.string().optional(),
+          })
+        )
     )
     .mutation(async ({ ctx, input }) => {
       const { name, abbreviation, password, profilePicture } = input;
@@ -199,5 +204,29 @@ export const teamRouter = createTRPCRouter({
           }
         }
       }
+    }),
+  edit: protectedProcedure
+    .input(
+      newTeamSchema
+        .partial()
+        .omit({ profilePicture: true, password: true })
+        .and(
+          z.object({
+            teamId: z.string(),
+            profilePicture: z.string().optional(),
+          })
+        )
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { teamId, name, abbreviation, profilePicture } = input;
+
+      await ctx.prisma.team.update({
+        where: { id: teamId },
+        data: {
+          name,
+          abbreviation,
+          profilePicture,
+        },
+      });
     }),
 });


### PR DESCRIPTION
- Add tabs ui component to teams tab
- Remove ring from Team component
- Add current tab stored in url
- Add serach input and filters button
- Add addTeamButton prop to TeamList component
- Add lazy loading to your teams tab
- Extract explore tab into a component
- Add infinite scroll to explore tab
- Add search query
- Change comments
- Remove filter button
- Fix mobile view of create team form
- prepare for edit form
- Add infering of default values
- Finish team editing
